### PR TITLE
40 package register automatizacion

### DIFF
--- a/src/views/Dashboard/PackageRegister.vue
+++ b/src/views/Dashboard/PackageRegister.vue
@@ -76,7 +76,14 @@
             </q-tr>
           </template> -->
                         <template v-slot:body="props">
-                            <q-tr :props="props">
+                            <q-tr
+                                :props="props"
+                                :class="
+                                    props.rowIndex == activeRowIndex
+                                        ? 'bg-secondary'
+                                        : ''
+                                "
+                            >
                                 <q-td key="tracking" :props="props">
                                     {{ props.row.tracking }}
                                     <q-popup-edit
@@ -147,6 +154,10 @@
                                         self="top middle"
                                         content-class="bg-primary"
                                         :offset="[10, 10]"
+                                        v-if="
+                                            props.row.aditionalCharges.length >
+                                            0
+                                        "
                                     >
                                         <div
                                             class="text-subtitle2"
@@ -203,7 +214,12 @@
                                             round
                                             flat
                                             color="primary"
-                                            @click="populateForm(props.row)"
+                                            @click="
+                                                populateForm(
+                                                    props.row,
+                                                    props.rowIndex
+                                                )
+                                            "
                                         />
                                         <q-btn
                                             icon="fas fa-times"
@@ -247,6 +263,8 @@
                                 :rules="[
                                     val => !!val || 'El campo es obligatorio',
                                 ]"
+                                ref="box"
+                                v-on:keyup.enter="saveDataLocally()"
                             />
                             <q-input
                                 filled
@@ -257,6 +275,7 @@
                                 :rules="[
                                     val => !!val || 'El campo es obligatorio',
                                 ]"
+                                v-on:keyup.enter="saveDataLocally()"
                             />
                             <q-input
                                 filled
@@ -267,6 +286,7 @@
                                 :rules="[
                                     val => !!val || 'El campo es obligatorio',
                                 ]"
+                                v-on:keyup.enter="saveDataLocally()"
                             />
                             <q-input
                                 filled
@@ -277,6 +297,7 @@
                                 :rules="[
                                     val => !!val || 'El campo es obligatorio',
                                 ]"
+                                v-on:keyup.enter="saveDataLocally()"
                             />
                             <q-input
                                 filled
@@ -287,6 +308,7 @@
                                 :rules="[
                                     val => !!val || 'El campo es obligatorio',
                                 ]"
+                                v-on:keyup.enter="saveDataLocally()"
                             />
                             <q-input
                                 filled
@@ -508,6 +530,7 @@ import * as api from '@/api/api'
 export default {
     data() {
         return {
+            activeRowIndex: null,
             additionalChargesDialog: false,
             uploadFile: null,
             displayLoading: false,
@@ -668,7 +691,7 @@ export default {
             this.chargeName = ''
             this.chargeAmount = ''
         },
-        populateForm(selectedPackage) {
+        populateForm(selectedPackage, row) {
             this.isEditingFile = true
             this.form = {
                 id: selectedPackage.id,
@@ -682,6 +705,8 @@ export default {
                 supplierInvoiceDate: selectedPackage.supplierInvoiceDate,
                 aditionalCharges: selectedPackage.aditionalCharges,
             }
+            this.activeRowIndex = row
+            this.$refs.box.focus()
         },
         handleInvoices() {
             this.displayLoading = true
@@ -840,6 +865,9 @@ export default {
                 return 'NaN'
                 console.log(error)
             }
+        },
+        saveDataLocally() {
+            alert('data saved locally')
         },
     },
     mounted() {

--- a/src/views/Dashboard/PackageRegister.vue
+++ b/src/views/Dashboard/PackageRegister.vue
@@ -44,6 +44,14 @@
                         </template>
                     </q-file>
                 </div>
+                <q-space />
+                <div class="col-lg-2">
+                    <q-btn
+                        label="Actualizar BD"
+                        color="accent"
+                        class="full-width"
+                    />
+                </div>
             </div>
             <div class="row" style="margin-bottom: 65px">
                 <div class="col-lg-8 q-px-md">
@@ -875,7 +883,7 @@ export default {
         },
         saveDataLocally() {
             if (this.isEditingFile) {
-                alert('data saved locally')
+                // INSERT "SAVE DATA LOCALLY" CODE HERE
                 this.activeRowIndex++
                 if (this.activeRowIndex < this.filteredPackagesData.length) {
                     this.populateForm(

--- a/src/views/Dashboard/PackageRegister.vue
+++ b/src/views/Dashboard/PackageRegister.vue
@@ -242,7 +242,13 @@
                 <div class="col-lg-4 q-px-md">
                     <q-card class="full-width">
                         <q-card-section>
-                            <div class="text-h6">Registrar</div>
+                            <div class="text-h6">
+                                {{
+                                    isEditingFile
+                                        ? 'Actualizar paquete'
+                                        : 'Registrar nuevo paquete'
+                                }}
+                            </div>
                         </q-card-section>
 
                         <q-card-section>
@@ -395,26 +401,20 @@
                             <q-btn flat color="warning" @click="clear()"
                                 >Cancelar</q-btn
                             >
-                            <!-- <q-btn
+                            <q-btn
                                 v-if="isEditingFile"
                                 flat
                                 color="primary"
-                                @click="updatePackage()"
-                                >Siguiente</q-btn
-                            >
+                                @click="saveDataLocally()"
+                                label="Siguiente"
+                            />
                             <q-btn
                                 v-if="!isEditingFile"
                                 flat
                                 color="primary"
                                 @click="Generate()"
                                 >Registrar</q-btn
-                            > -->
-                            <q-btn
-                                flat
-                                color="primary"
-                                @click="saveDataLocally()"
-                                label="Siguiente"
-                            />
+                            >
                         </q-card-actions>
                     </q-card>
                 </div>
@@ -805,6 +805,7 @@ export default {
             this.form.supplierInvoiceDate = ''
             this.form.aditionalCharges = []
             this.isEditingFile = false
+            this.activeRowIndex = null
         },
         async Generate() {
             this.displayLoading = true
@@ -873,7 +874,7 @@ export default {
             }
         },
         saveDataLocally() {
-            if (this.activeRowIndex != null) {
+            if (this.isEditingFile) {
                 alert('data saved locally')
                 this.activeRowIndex++
                 if (this.activeRowIndex < this.filteredPackagesData.length) {
@@ -881,6 +882,12 @@ export default {
                         this.filteredPackagesData[this.activeRowIndex],
                         this.activeRowIndex
                     )
+                } else {
+                    this.displayAlert = true
+                    this.alertTitle = 'Finalizado'
+                    this.alertMessage = 'Has llegado al final de la lista.'
+                    this.alertType = 'success'
+                    this.clear()
                 }
             }
         },

--- a/src/views/Dashboard/PackageRegister.vue
+++ b/src/views/Dashboard/PackageRegister.vue
@@ -395,12 +395,12 @@
                             <q-btn flat color="warning" @click="clear()"
                                 >Cancelar</q-btn
                             >
-                            <q-btn
+                            <!-- <q-btn
                                 v-if="isEditingFile"
                                 flat
                                 color="primary"
                                 @click="updatePackage()"
-                                >Actualizar</q-btn
+                                >Siguiente</q-btn
                             >
                             <q-btn
                                 v-if="!isEditingFile"
@@ -408,7 +408,13 @@
                                 color="primary"
                                 @click="Generate()"
                                 >Registrar</q-btn
-                            >
+                            > -->
+                            <q-btn
+                                flat
+                                color="primary"
+                                @click="saveDataLocally()"
+                                label="Siguiente"
+                            />
                         </q-card-actions>
                     </q-card>
                 </div>
@@ -867,7 +873,16 @@ export default {
             }
         },
         saveDataLocally() {
-            alert('data saved locally')
+            if (this.activeRowIndex != null) {
+                alert('data saved locally')
+                this.activeRowIndex++
+                if (this.activeRowIndex < this.filteredPackagesData.length) {
+                    this.populateForm(
+                        this.filteredPackagesData[this.activeRowIndex],
+                        this.activeRowIndex
+                    )
+                }
+            }
         },
     },
     mounted() {


### PR DESCRIPTION
**Card**
No. 40

**What to test**
Se actualizo la vista de /package-register para editar los campos de los paquetes con el uso del teclado.

**How to test**
- [x] Al clickear en editar algun paquete la fila hace hightlight, el campo de "casillero" hace focus y se popula la data en el form
- [x] Al presionar enter en alguno de los inputs de casillero, peso, largo, alto o ancho el highlight pasa a la fila siguiente y el form se popula con la data correspondienete
- [x] Si se llega al dinal de la tabla, se muestra un alert notificando al usuario que ha terminado y se vacia la tabla
- [x] Se agergo boton en la esquina superior derecha para enviar la nueva data a DB

**Screenshots**

![image](https://user-images.githubusercontent.com/13292756/97477275-6984f800-191d-11eb-9031-fedb2e31c5cd.png)

![image](https://user-images.githubusercontent.com/13292756/97477304-74d82380-191d-11eb-9db9-dffc230a6d17.png)

