### PR TITLE
reset pounds in affiliate card submit

### DIFF
--- a/src/layouts/User.vue
+++ b/src/layouts/User.vue
@@ -345,6 +345,8 @@ export default {
         sendAffiliatedNo() {
             this.displayLoadingForAffiliated = true
             this.userInformation.user.affiliateCardNo = parseInt(this.affiliatedNo)
+            this.userInformation.user.poundsCount = 0
+            this.value = 0
             api.UpdateUserInformationById({
                 uid: this.uid,
                 user: this.userInformation.user,


### PR DESCRIPTION
Card 94

**Se resetea el conteo de libras al subscribirse a un affiliate card **

- [x] Ahora siempre se pone en cero el valor de las libras